### PR TITLE
fixing tv show trailers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.1.3",
     "firebase": "^9.13.0",
-    "movie-trailer": "^2.1.0",
+    "movie-trailer": "https://github.com/vvoinea-gpsw/movie-trailer",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.4",

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -44,6 +44,18 @@ function Row({ title, fetchUrl, isLargeRow = false }) {
           ""
       )
         .then((url) => {
+          if (url == null) {
+            return movieTrailer(
+              movie?.title ||
+                movie?.name ||
+                movie?.original_name ||
+                movie?.original_title ||
+                "", {videoType: "tv"}
+            )
+          }
+          else return url
+        })
+        .then((url) => {
           console.log(
             movie?.title ||
               movie?.name ||


### PR DESCRIPTION
I forked the movie-trailer here: https://github.com/vvoinea-gpsw/movie-trailer
to accept an extra parameter in options like 
`options = {videoType: "movie"}`

SHOE ON HEAD PICTURE:
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/71024310/199995660-bf381cae-3403-4d2c-9131-a78a91f15b06.png">
